### PR TITLE
Feat/ng word

### DIFF
--- a/go/livecomment_handler.go
+++ b/go/livecomment_handler.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"os"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/jmoiron/sqlx"
@@ -334,21 +335,8 @@ func postLivecommentHandler(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusInternalServerError, "failed to get NG words: "+err.Error())
 	}
 
-	var hitSpam int
 	for _, ngword := range ngwords {
-		query := `
-		SELECT COUNT(*)
-		FROM
-		(SELECT ? AS text) AS texts
-		INNER JOIN
-		(SELECT CONCAT('%', ?, '%')	AS pattern) AS patterns
-		ON texts.text LIKE patterns.pattern;
-		`
-		if err := tx.GetContext(ctx, &hitSpam, query, req.Comment, ngword.Word); err != nil {
-			return echo.NewHTTPError(http.StatusInternalServerError, "failed to get hitspam: "+err.Error())
-		}
-		c.Logger().Infof("[hitSpam=%d] comment = %s", hitSpam, req.Comment)
-		if hitSpam >= 1 {
+		if strings.Contains(req.Comment, ngword.Word) {
 			return echo.NewHTTPError(http.StatusBadRequest, "このコメントがスパム判定されました")
 		}
 	}

--- a/go/livestream_handler.go
+++ b/go/livestream_handler.go
@@ -504,28 +504,19 @@ func fillLivestreamResponse(ctx context.Context, tx *sqlx.Tx, livestreamModel Li
 		tagIDs[i] = tagModel.TagID
 	}
 
-	var tagModels []TagModel
 	var tags []Tag
 	if len(tagIDs) > 0 {
-		query, args, err := sqlx.In("SELECT * FROM tags WHERE id IN (?)", tagIDs)
+		query, args, err := sqlx.In("SELECT id, name FROM tags WHERE id IN (?)", tagIDs)
 		if err != nil {
 			return Livestream{}, err
 		}
 		query = tx.Rebind(query)
 
-		if err := tx.SelectContext(ctx, &tagModels, query, args...); err != nil {
+		if err := tx.SelectContext(ctx, &tags, query, args...); err != nil {
 			return Livestream{}, err
 		}
-
-		// タグ構造体への変換
-		tags = make([]Tag, len(tagModels))
-		for i, tagModel := range tagModels {
-			tags[i] = Tag{
-				ID:   tagModel.ID,
-				Name: tagModel.Name,
-			}
-		}
 	} else {
+
 		tags = []Tag{}
 	}
 


### PR DESCRIPTION
> 17723

```
Count    Total     Mean   Stddev     Min   P50.0   P90.0   P95.0   P99.0     Max    2xx  3xx  4xx  5xx  TotalBytes   MinBytes  MeanBytes   MaxBytes  Request
   16  248.626  15.5391   6.9517   2.446  20.000  20.002  20.003  20.003  20.003      2    0   14    0         272          0         17        139  GET /api/user/[\w]+/statistics
  192  103.319   0.5381   0.1340   0.036   0.562   0.683   0.724   0.785   0.788    190    0    2    0    11223340          0      58454      63598  GET /api/livestream/search?limit=<num>
  797   86.337   0.1083   0.0603   0.000   0.084   0.206   0.235   0.287   0.361    795    0    1    1      373550         67        468        522  POST /api/register
12243   76.689   0.0063   0.0076   0.000   0.004   0.015   0.021   0.036   0.214  12242    0    1    0   712491646          0      58195     164992  GET /api/user/[\w]+/icon
    6   65.638  10.9397   9.0832   0.627  20.001  20.002  20.002  20.002  20.002      2    0    4    0         202          0         33        102  GET /api/livestream/<num>/statistics
  667   62.074   0.0931   0.0369   0.010   0.095   0.139   0.154   0.187   0.293    666    0    1    0      319847          0        479      22372  GET /api/livestream
  110   58.439   0.5313   0.3877   0.000   0.552   1.022   1.143   1.227   1.249    106    0    4    0      120034          0       1091       1462  POST /api/livestream/reservation
  963   57.447   0.0597   0.0505   0.001   0.043   0.135   0.164   0.219   0.306    961    0    2    0    46128011          0      47900     172151  GET /api/livestream/<num>/livecomment
  998   49.902   0.0500   0.0462   0.001   0.036   0.119   0.148   0.204   0.251    997    0    1    0    37295928          0      37370     156442  GET /api/livestream/<num>/reaction
 1435   37.820   0.0264   0.0173   0.000   0.023   0.049   0.061   0.080   0.124   1433    0    2    0     2760489          0       1923       2140  POST /api/livestream/<num>/livecomment
  979   24.017   0.0245   0.0169   0.002   0.021   0.047   0.059   0.079   0.094    979    0    0    0     1817468       1552       1856       2202  POST /api/livestream/<num>/reaction
   23   19.549   0.8500   0.6272   0.097   0.998   1.629   1.642   1.703   1.703     23    0    0    0     2688821      99912     116905     137353  GET /api/livestream/search?tag=.+
  795   17.635   0.0222   0.0157   0.003   0.019   0.045   0.053   0.067   0.096    731    0    1   63       21295          0         26        154  POST /api/icon
  802    5.451   0.0068   0.0079   0.000   0.003   0.016   0.023   0.038   0.083    800    0    2    0         128          0          0         64  POST /api/login
  237    3.569   0.0151   0.0355   0.000   0.004   0.033   0.084   0.172   0.321    219    0    0   18      199836          3        843      24466  GET /api/livestream/<num>/report
   92    2.577   0.0280   0.0326   0.001   0.015   0.061   0.084   0.201   0.201     92    0    0    0     1137499          3      12364      21057  GET /api/livestream/<num>/livecomment?limit=<num>
   91    2.173   0.0239   0.0322   0.001   0.013   0.050   0.069   0.200   0.200     91    0    0    0      827979          3       9098      20279  GET /api/livestream/<num>/reaction?limit=<num>
    1    2.035   2.0350   0.0000   2.035   2.035   2.035   2.035   2.035   2.035      1    0    0    0          27         27         27         27  POST /api/initialize
   59    1.709   0.0290   0.0199   0.001   0.027   0.057   0.063   0.103   0.103     53    0    6    0      137354         57       2328       2664  POST /api/livestream/<num>/livecomment/<num>/report
```