### PR TITLE
"no rows in result set"  エラーの修正

### DIFF
--- a/go/livecomment_handler.go
+++ b/go/livecomment_handler.go
@@ -582,7 +582,9 @@ func fillLivecommentReportResponse(ctx context.Context, tx *sqlx.Tx, reportModel
 
 	livecommentModel := LivecommentModel{}
 	if err := tx.GetContext(ctx, &livecommentModel, "SELECT * FROM livecomments WHERE id = ?", reportModel.LivecommentID); err != nil {
-		return LivecommentReport{}, err
+		if !errors.Is(err, sql.ErrNoRows) {
+			return LivecommentReport{}, err
+		}
 	}
 	livecomment, err := fillLivecommentResponse(ctx, tx, livecommentModel)
 	if err != nil {

--- a/go/livestream_handler.go
+++ b/go/livestream_handler.go
@@ -470,7 +470,9 @@ func getLivecommentReportsHandler(c echo.Context) error {
 
 	var reportModels []*LivecommentReportModel
 	if err := tx.SelectContext(ctx, &reportModels, "SELECT * FROM livecomment_reports WHERE livestream_id = ?", livestreamID); err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, "failed to get livecomment reports: "+err.Error())
+		if !errors.Is(err, sql.ErrNoRows) {
+			return echo.NewHTTPError(http.StatusInternalServerError, "failed to get livecomment reports: "+err.Error())
+		}
 	}
 
 	reports := make([]LivecommentReport, len(reportModels))


### PR DESCRIPTION
refs #1 

error handlingが甘いところがありそう

```
$ journalctl -xu isupipe-go
...
Nov 24 08:39:22 ip-192-168-0-12 isupipe[6852]: {"time":"2024-11-24T08:39:22.311221989Z","level":"ERROR","prefix":"echo","file":"main.go","line":"225","message":"error at /api/livestream/:livestream_id/report: code=500, message=failed to fill livecomment report: sql: no rows in result set"}
Nov 24 08:39:22 ip-192-168-0-12 isupipe[6852]: {"time":"2024-11-24T08:39:22.743592265Z","level":"ERROR","prefix":"echo","file":"main.go","line":"225","message":"error at /api/livestream/:livestream_id/report: code=500, message=failed to fill livecomment report: sql: no rows in result set"}
Nov 24 08:39:25 ip-192-168-0-12 isupipe[6852]: {"time":"2024-11-24T08:39:25.391033344Z","level":"ERROR","prefix":"echo","file":"main.go","line":"225","message":"error at /api/livestream/:livestream_id/report: code=500, message=failed to fill livecomment report: sql: no rows in result set"}
Nov 24 08:39:25 ip-192-168-0-12 isupipe[6852]: {"time":"2024-11-24T08:39:25.950824551Z","level":"ERROR","prefix":"echo","file":"main.go","line":"225","message":"error at /api/livestream/:livestream_id/report: code=500, message=failed to fill livecomment report: sql: no rows in result set"}
Nov 24 08:39:34 ip-192-168-0-12 isupipe[6852]: {"time":"2024-11-24T08:39:34.299745536Z","level":"ERROR","prefix":"echo","file":"main.go","line":"225","message":"error at /api/livestream/:livestream_id/report: code=500, message=failed to fill livecomment report: sql: no rows in result set"}
Nov 24 08:39:35 ip-192-168-0-12 isupipe[6852]: {"time":"2024-11-24T08:39:35.300584378Z","level":"ERROR","prefix":"echo","file":"main.go","line":"225","message":"error at /api/livestream/:livestream_id/report: code=500, message=failed to fill livecomment report: sql: no rows in result set"}
Nov 24 08:39:44 ip-192-168-0-12 isupipe[6852]: {"time":"2024-11-24T08:39:44.585583443Z","level":"ERROR","prefix":"echo","file":"main.go","line":"225","message":"error at /api/livestream/:livestream_id/report: code=500, message=failed to fill livecomment report: sql: no rows in result set"}
```